### PR TITLE
pubspec.yaml -> this package is Android only

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,10 @@ dependencies:
 # The following section is specific to Flutter.
 flutter:
   plugin:
-    androidPackage: com.bostrot.flutterandroidpip
-    pluginClass: FlutterAndroidPipPlugin
+    platforms:
+      android:
+        androidPackage: com.bostrot.flutterandroidpip
+        pluginClass: FlutterAndroidPipPlugin
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:


### PR DESCRIPTION
I took the layout from https://github.com/flutter/plugins/blob/master/packages/path_provider/path_provider/pubspec.yaml, but I have not tried it out locally yet. I could not find any guide on this. Please try it yourself :)

This should prevent pub.dev to show this plugin as "Android iOS Web".